### PR TITLE
chore: update CI workflow for buf lint and format check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Lint Protobuf Files
+name: Lint and Format Protobuf Files
 
 on:
   pull_request:
@@ -12,9 +12,18 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
-      - name: Install buf
-        run: |
-          curl -sSL https://github.com/bufbuild/buf/releases/latest/download/buf-Linux-x86_64 -o /usr/local/bin/buf
-          chmod +x /usr/local/bin/buf
+      - name: Setup buf
+        uses: bufbuild/buf-setup-action@v1.50.0
+        with:
+          version: 1.50.0
+
+      - name: Check buf version
+        run: buf --version
+
       - name: Run buf lint
-        run: buf lint
+        uses: bufbuild/buf-lint-action@v1
+        with:
+          input: proto
+
+      - name: Check formatting
+        run: buf format --exit-code --diff


### PR DESCRIPTION
## 概要
このPRでは、`.proto` ファイルのLintおよびフォーマットチェックを行うGitHub Actionsのワークフローを改善しました。

## 変更点
- `bufbuild/buf-setup-action@v1.50.0` を使用して `buf` をセットアップ
- `bufbuild/buf-lint-action@v1` を導入し、従来の手動 `buf lint` を置き換え
- `buf format --exit-code --diff` を追加し、フォーマットチェックを強制
- ワークフローの名称を `Lint and Format Protobuf Files` に変更し、目的を明確化

## 目的
- **公式の `bufbuild` Actions を活用し、CIの簡素化・メンテナンス性向上**
- **Lint に加えてフォーマットチェックも行い、コード品質を統一**
- **ワークフローをより分かりやすく整理し、実行結果の見やすさを向上**

## 動作確認
- [x] `act`を用いて、CIが正常に実行されることを確認
  - [x] `.proto` のLintチェックが期待通り動作することを確認
  - [x] `.proto` のフォーマットチェックが機能することを確認